### PR TITLE
Return 301 for channel redirect

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -22,7 +22,7 @@ module.exports = () => {
       .replace(/\+/g, '-')
       .replace(/\//g, '_')
       .replace(/=/g, '~')
-    res.redirect(channel)
+    res.redirect(301, channel)
   })
 
   app.get('/:channel', (req, res, next) => {

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -26,7 +26,7 @@ describe('server', () => {
   describe('GET /', () => {
     it('redirects from / to /TOKEN', async () => {
       const res = await request(server).get('/')
-      expect(res.status).toBe(302)
+      expect(res.status).toBe(301)
       expect(typeof res.headers.location).toBe('string')
     })
   })


### PR DESCRIPTION
Given an error in the CLI, this PR changes the new channel redirect to use a 301 status so that its not seen as an error, and the CLI still works.

Closes #10 