### PR TITLE
Replace Heroku-specific props with real ones

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -62,7 +62,8 @@ module.exports = () => {
   app.post('/:channel', (req, res) => {
     events.emit(req.params.channel, {
       ...req.headers,
-      body: req.body
+      body: req.body,
+      timestamp: Date.now()
     })
     res.status(200).end()
   })

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -42,7 +42,7 @@ export default class App extends Component {
     const json = JSON.parse(message.data)
 
     // Prevent duplicates in the case of redelivered payloads
-    if (this.state.log.findIndex(l => l.id === json['X-GitHub-Delivery']) === -1) {
+    if (this.state.log.findIndex(l => l.id === json['x-github-delivery']) === -1) {
       this.setState({
         log: [...this.state.log, json]
       })

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -42,7 +42,7 @@ export default class App extends Component {
     const json = JSON.parse(message.data)
 
     // Prevent duplicates in the case of redelivered payloads
-    if (this.state.log.findIndex(l => l.id === json['x-request-id']) === -1) {
+    if (this.state.log.findIndex(l => l.id === json['X-GitHub-Delivery']) === -1) {
       this.setState({
         log: [...this.state.log, json]
       })

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -42,7 +42,8 @@ export default class App extends Component {
     const json = JSON.parse(message.data)
 
     // Prevent duplicates in the case of redelivered payloads
-    if (this.state.log.findIndex(l => l.id === json['x-github-delivery']) === -1) {
+    const idProp = 'x-github-delivery'
+    if (this.state.log.every(l => l[idProp] === json[idProp])) {
       this.setState({
         log: [...this.state.log, json]
       })

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -61,8 +61,7 @@ export default class ListItem extends Component {
 
     const event = item['x-github-event']
     const payload = item.body
-    const timestamp = parseInt(item['x-request-start'], 10)
-    const id = item['x-request-id']
+    const id = item['x-github-delivery']
 
     let icon
 
@@ -81,7 +80,7 @@ export default class ListItem extends Component {
             {icon}
           </div>
           <span className="input-monospace">{event}</span>
-          <time className="f6" style={{ marginLeft: 'auto' }}>{moment(timestamp).fromNow()}</time>
+          <time className="f6" style={{ marginLeft: 'auto' }}>{moment(item.timestamp).fromNow()}</time>
           <button onClick={this.toggleExpanded} className="ellipsis-expander ml-2"><KebabHorizontalIcon height={12} /></button>
         </div>
 
@@ -90,7 +89,7 @@ export default class ListItem extends Component {
             <div className="d-flex flex-justify-between flex-items-start">
               <div>
                 <p><strong>Event ID:</strong> <code>{id}</code></p>
-                <EventDescription event={event} payload={payload} timestamp={timestamp} />
+                <EventDescription event={event} payload={payload} timestamp={item.timestamp} />
               </div>
 
               <div>


### PR DESCRIPTION
Little did I know some of the properties of payloads I was referencing were added on by Heroku, which of course means they aren't present anywhere else (hat-tip to @tcbyrd for noticing that). This PR makes use of the right headers, as well as sets a timestamp for each new payload. It also fixes the duplication check which now works because the event IDs are the same.