### PR TITLE
Ping every 30 seconds to keep the connection alive

### DIFF
--- a/lib/keep-alive.js
+++ b/lib/keep-alive.js
@@ -1,0 +1,19 @@
+module.exports = class KeepAlive {
+  constructor (callback, delay) {
+    this.callback = callback
+    this.delay = delay
+  }
+
+  start () {
+    this.id = setInterval(this.callback, this.delay)
+  }
+
+  stop () {
+    clearInterval(this.id)
+  }
+
+  reset () {
+    this.stop()
+    this.start()
+  }
+}

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,6 +5,8 @@ const bodyParser = require('body-parser')
 const EventEmitter = require('events')
 const path = require('path')
 
+const KeepAlive = require('./keep-alive')
+
 // Tiny logger to prevent logs in tests
 const log = process.env.NODE_ENV === 'test' ? _ => _ : console.log
 
@@ -42,23 +44,33 @@ module.exports = () => {
       next()
     }
   }, sse, (req, res) => {
-    // Allow CORS
-    res.setHeader('Access-Control-Allow-Origin', '*')
-    res.json({}, 'ready')
+    function receive (data) {
+      res.json(data)
+      keepAlive.reset()
+    }
+
+    function close () {
+      events.removeListener(channel, receive)
+      keepAlive.stop()
+      log('Client disconnected', channel, events.listenerCount(channel))
+    }
 
     const channel = req.params.channel
 
+    // Setup interval to ping every 30 seconds to keep the connection alive
+    const keepAlive = new KeepAlive(() => res.json({}, 'ping'), 30 * 1000)
+    keepAlive.start()
+
+    // Allow CORS
+    res.setHeader('Access-Control-Allow-Origin', '*')
+
     // Listen for events on this channel
-    events.on(channel, res.json)
+    events.on(channel, receive)
 
-    // Ping every 30 seconds to keep the connection alive
-    const interval = setInterval(() => res.json({}, 'ping'), 30 * 1000)
+    // Clean up when the client disconnects
+    res.on('close', close)
 
-    res.on('close', () => {
-      events.removeListener(channel, res.json)
-      clearInterval(interval)
-      log('Client disconnected', channel, events.listenerCount(channel))
-    })
+    res.json({}, 'ready')
 
     log('Client connected', channel, events.listenerCount(channel))
   })

--- a/lib/server.js
+++ b/lib/server.js
@@ -51,8 +51,12 @@ module.exports = () => {
     // Listen for events on this channel
     events.on(channel, res.json)
 
+    // Ping every 30 seconds to keep the connection alive
+    const interval = setInterval(() => res.json({}, 'ping'), 30 * 1000)
+
     res.on('close', () => {
       events.removeListener(channel, res.json)
+      clearInterval(interval)
       log('Client disconnected', channel, events.listenerCount(channel))
     })
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -44,13 +44,13 @@ module.exports = () => {
       next()
     }
   }, sse, (req, res) => {
-    function receive (data) {
+    function send (data) {
       res.json(data)
       keepAlive.reset()
     }
 
     function close () {
-      events.removeListener(channel, receive)
+      events.removeListener(channel, send)
       keepAlive.stop()
       log('Client disconnected', channel, events.listenerCount(channel))
     }
@@ -65,7 +65,7 @@ module.exports = () => {
     res.setHeader('Access-Control-Allow-Origin', '*')
 
     // Listen for events on this channel
-    events.on(channel, receive)
+    events.on(channel, send)
 
     // Clean up when the client disconnects
     res.on('close', close)


### PR DESCRIPTION
https://devcenter.heroku.com/articles/request-timeout#long-polling-and-streaming-responses

It works!

```
curl -H 'Accept: text/event-stream'  https://smee.io/omg                                        

id: 0
event: ready
data: {}

id: 1
event: ping
data: {}

id: 2
event: ping
data: {}

id: 3
event: ping
data: {}
```