### PR TITLE
Add logs only when they don't have an existing index (return value is -1)

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -54,7 +54,7 @@ export default class App extends Component {
 
     // Prevent duplicates in the case of redelivered payloads
     const idProp = 'x-github-delivery'
-    if (this.state.log.findIndex(l => l[idProp] === json[idProp]) > -1) {
+    if (this.state.log.findIndex(l => l[idProp] === json[idProp]) === -1) {
       this.setState({
         log: [...this.state.log, json]
       })


### PR DESCRIPTION
@JasonEtco I was having some problems with payloads showing up after #24 was deployed, so I took a minute to look over the logic to check for duplicates and noticed it was backwards. To avoid duplicates, we need to only log when the `findIndex()` method returns `-1` (meaning, the payload's ID does not exist in the log yet). This is also the value that gets returned on an empty array. I deployed this to a test server and sent a few payloads and I think it's working as intended.